### PR TITLE
Relax Default impls

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -20,7 +20,7 @@ use std::marker::PhantomData;
 ///
 /// assert_eq!(map.len(), 3);
 /// ```
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct FlatMultimap<K, V, S = RandomState> {
     hash_builder: S,
     table: RawTable<(K, V)>,
@@ -287,6 +287,18 @@ impl<K, V, S> IntoIterator for FlatMultimap<K, V, S> {
     fn into_iter(self) -> IntoIter<K, V> {
         IntoIter {
             iter: self.table.into_iter(),
+        }
+    }
+}
+
+impl<K, V, S> Default for FlatMultimap<K, V, S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        FlatMultimap {
+            hash_builder: Default::default(),
+            table: RawTable::new(),
         }
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -19,7 +19,7 @@ use std::iter::FusedIterator;
 ///
 /// assert_eq!(set.len(), 3);
 /// ```
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct FlatMultiset<T, S = RandomState> {
     map: FlatMultimap<T, (), S>,
 }
@@ -186,6 +186,17 @@ impl<T, S> IntoIterator for FlatMultiset<T, S> {
     fn into_iter(self) -> IntoIter<T> {
         IntoIter {
             iter: self.map.into_keys(),
+        }
+    }
+}
+
+impl<T, S> Default for FlatMultiset<T, S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        FlatMultiset {
+            map: FlatMultimap::default(),
         }
     }
 }


### PR DESCRIPTION
Deriving them adds a bound of `K: Default` (and `V`, `T` respectively) as it won't inspect the field types precisely to note that they have more generic impls, too. Also the macro won't make the exact field types part of the public API.

By manually implementing them it is possible to default-construct sets and maps of non-Default types with similar semantics as vector: as an empty container.